### PR TITLE
Added "stats_total_kills" placeholder

### DIFF
--- a/proxy-plugin/src/main/java/com/andrei1058/bedwars/proxy/support/papi/SupportPAPI.java
+++ b/proxy-plugin/src/main/java/com/andrei1058/bedwars/proxy/support/papi/SupportPAPI.java
@@ -68,6 +68,9 @@ public class SupportPAPI extends PlaceholderExpansion {
             case "stats_kills":
                 replay = String.valueOf(BedWarsProxy.getStatsCache().getPlayerKills(p.getUniqueId()));
                 break;
+            case "stats_total_kills":
+                replay = String.valueOf(BedWarsProxy.getStatsCache().getPlayerKills(p.getUniqueId()) + BedWarsProxy.getStatsCache().getPlayerFinalKills(p.getUniqueId()));
+                break;
             case "stats_wins":
                 replay = String.valueOf(BedWarsProxy.getStatsCache().getPlayerWins(p.getUniqueId()));
                 break;


### PR DESCRIPTION
Small PR that adds the **%bw1058_stats_total_kills%** placeholder, just like the one from the main plugin. For some reason this placeholder didn't exist in bwproxy.