### PR TITLE
Removed disbanding of party upon joining

### DIFF
--- a/proxy-plugin/src/main/java/com/andrei1058/bedwars/proxy/arenamanager/LegacyArena.java
+++ b/proxy-plugin/src/main/java/com/andrei1058/bedwars/proxy/arenamanager/LegacyArena.java
@@ -235,7 +235,6 @@ public class LegacyArena implements CachedArena {
                         addPlayer(pl, player.getName());
                     }
                 }
-                getParty().disband(player.getUniqueId());
             }
         }
 


### PR DESCRIPTION
I tested this ingame, there is no longer a disband attempt, no error in console when trying to disband (since there is no disbanding) and party "pulling" players into the game worked fine