### PR TITLE
Fix softdepend

### DIFF
--- a/proxy-plugin/src/main/resources/plugin.yml
+++ b/proxy-plugin/src/main/resources/plugin.yml
@@ -4,9 +4,4 @@ description: Arena connecter for BedWars1058
 main: com.andrei1058.bedwars.proxy.BedWarsProxy
 author: andrei1058
 api-version: '1.13'
-softdepend:
-  - Parties
-  - Partys
-  - PartyAndFriends
-  - PlaceholderAPI
-  - Spigot-Party-API-PAF
+softdepend: ['PlaceholderAPI', 'Spigot-Party-API-PAF', 'Parties', 'PartyAndFriends']


### PR DESCRIPTION
Softdependencies have to be written in []. Not doing so may result in the plugin being loaded before the softdependencies have loaded, causing for example that the Party And Friends integration does not always load