### PR TITLE
Fix for PartyAndFriends NPE issue

### DIFF
--- a/proxy-plugin/src/main/java/com/andrei1058/bedwars/proxy/party/PAF.java
+++ b/proxy-plugin/src/main/java/com/andrei1058/bedwars/proxy/party/PAF.java
@@ -89,6 +89,10 @@ public class PAF implements Party{ //Party And Friends Support Added by JT122406
 
     @Override
     public UUID getOwner(UUID player) {
-        return getPAFParty(player).getLeader().getUniqueId();
+        PlayerParty playerParty = getPAFParty(player);
+        if (playerParty == null) {
+            return null;
+        }
+        return playerParty.getLeader().getUniqueId();
     }
 }

--- a/proxy-plugin/src/main/java/com/andrei1058/bedwars/proxy/party/PAF.java
+++ b/proxy-plugin/src/main/java/com/andrei1058/bedwars/proxy/party/PAF.java
@@ -74,12 +74,20 @@ public class PAF implements Party{ //Party And Friends Support Added by JT122406
 
     @Override
     public boolean isMember(UUID owner, UUID check) {
-        return getPAFParty(owner).isInParty(PAFPlayerManager.getInstance().getPlayer(Bukkit.getPlayer(check)));
+        PlayerParty playerParty = getPAFParty(owner);
+        if (playerParty == null) {
+            return null;
+        }
+        return playerParty.isInParty(PAFPlayerManager.getInstance().getPlayer(Bukkit.getPlayer(check)));
     }
 
     @Override
     public void removePlayer(UUID owner, UUID target) {
-        getPAFParty(owner).leaveParty(PAFPlayerManager.getInstance().getPlayer(target));
+        PlayerParty playerParty = getPAFParty(owner);
+        if (playerParty == null) {
+            return null;
+        }
+        playerParty.leaveParty(PAFPlayerManager.getInstance().getPlayer(target));
     }
 
     @Override

--- a/proxy-plugin/src/main/java/com/andrei1058/bedwars/proxy/party/PAFBungeeCordParty.java
+++ b/proxy-plugin/src/main/java/com/andrei1058/bedwars/proxy/party/PAFBungeeCordParty.java
@@ -29,8 +29,11 @@ public class PAFBungeeCordParty implements Party {
 
     @Override
     public boolean isOwner(UUID p) {
-        PAFPlayer pafPlayer = PAFPlayerManager.getInstance().getPlayer(p);
-        return PartyManager.getInstance().getParty(pafPlayer).isLeader(pafPlayer);
+        PlayerParty playerParty = getPAFParty(player);
+        if (playerParty == null) {
+            return null;
+        }
+        return playerParty.isLeader(pafPlayer);
     }
 
     @Override
@@ -61,7 +64,11 @@ public class PAFBungeeCordParty implements Party {
 
     @Override
     public boolean isMember(UUID owner, UUID check) {
-        return getPAFParty(owner).isInParty(PAFPlayerManager.getInstance().getPlayer(check));
+        PlayerParty playerParty = getPAFParty(player);
+        if (playerParty == null) {
+            return null;
+        }
+        return playerParty.isInParty(PAFPlayerManager.getInstance().getPlayer(check));
     }
 
     @Override
@@ -75,6 +82,10 @@ public class PAFBungeeCordParty implements Party {
 
     @Override
     public UUID getOwner(UUID player) {
-        return getPAFParty(player).getLeader().getUniqueId();
+        PlayerParty playerParty = getPAFParty(player);
+        if (playerParty == null) {
+            return null;
+        }
+        return playerParty.getLeader().getUniqueId();
     }
 }

--- a/proxy-plugin/src/main/java/com/andrei1058/bedwars/proxy/party/PAFBungeeCordParty.java
+++ b/proxy-plugin/src/main/java/com/andrei1058/bedwars/proxy/party/PAFBungeeCordParty.java
@@ -29,7 +29,7 @@ public class PAFBungeeCordParty implements Party {
 
     @Override
     public boolean isOwner(UUID p) {
-        PlayerParty playerParty = getPAFParty(player);
+        PlayerParty playerParty = getPAFParty(p);
         if (playerParty == null) {
             return null;
         }
@@ -64,7 +64,7 @@ public class PAFBungeeCordParty implements Party {
 
     @Override
     public boolean isMember(UUID owner, UUID check) {
-        PlayerParty playerParty = getPAFParty(player);
+        PlayerParty playerParty = getPAFParty(owner);
         if (playerParty == null) {
             return null;
         }


### PR DESCRIPTION
The missing check for PartyPlayer causes NPE issues, similar to:

```
java.lang.NullPointerException: Cannot invoke "de.simonsator.partyandfriends.spigot.api.party.PlayerParty.getLeader()" because the return value of "com.andrei1058.bedwars.proxy.party.PAFBungeeCordParty.getPAFParty(java.util.UUID)" is null
```